### PR TITLE
Fix issue#10

### DIFF
--- a/src/interactive_kit/imageviewer.py
+++ b/src/interactive_kit/imageviewer.py
@@ -553,7 +553,7 @@ class ImageViewer():
             # If use_slider was not specified, default it to True if there are more than 5 input images
             self.use_slider = kwargs.get('use_slider', True if self.number_images > 5 else False)
             if self.use_slider:
-                self.change_img_slider = widgets.IntSlider(min=1, max=self.number_images, layout = widgets.Layout(width = '220px'))
+                self.change_img_slider = widgets.IntSlider(min=1, max=self.number_images, layout = widgets.Layout(width = '160px'), readout=False)
                 self.change_img_slider.observe(self.change_img_slider_callback, names='value')
             else:
                 # Button next image ('\U02190' for right arrow, not supported by python apparently)        
@@ -564,6 +564,9 @@ class ImageViewer():
                 self.button_prev.on_click(self.prev_button_callback)
                 # Wrap both buttons in one Horizontal widget
                 self.next_prev_buttons = widgets.HBox([self.button_prev, self.button_next])
+                
+            # HTML text to display the current image and total number of images
+            self.img_count_txt = widgets.HTML(value=f"1 / {self.number_images}")
         
         ##################### Text
         # Get stats. Instead of connecting to a callback, it is updated continuously
@@ -641,9 +644,9 @@ class ImageViewer():
         # If more than one image, add next and previous buttons or slider
         if self.current_image != None and self.number_images > 1:
             if not self.use_slider:
-                widget_list.insert(5, self.next_prev_buttons)
+                widget_list.insert(5, widgets.HBox([self.next_prev_buttons, self.img_count_txt]))
             else:
-                widget_list.insert(5, self.change_img_slider)
+                widget_list.insert(5, widgets.HBox([self.change_img_slider, self.img_count_txt]))
             
         # If extra widgets are given, add extra widgets button
         if self.extra_widgets:
@@ -1250,12 +1253,17 @@ class ImageViewer():
         '''
         # Restore self.im (attribute that holds AxesImage objects)
         self.im = []
+        # Initialize curr_img to the current image before change
+        curr_img = self.current_image
         # If image in display is to be changed (change = 1, -1, 2, ...), check that there is another image to go to. Otherwise, do nothing
         if self.current_image + change in range(self.number_images):
             # Update attribute self.current_image
             self.current_image += change
             
-            # Local variable
+            # Set the current image number in the text box
+            self.img_count_txt.value = f"{self.current_image + 1} / {self.number_images}"
+            
+            # Update curr_img
             curr_img = self.current_image
             
             # Keep track of wether the new and the previous image have the same shape 

--- a/src/interactive_kit/imageviewer.py
+++ b/src/interactive_kit/imageviewer.py
@@ -91,6 +91,9 @@ class ImageViewer():
         If the mode is only one image on display keeps track of which image is
         currently on display. If all images on display, it is set to `None`
     
+    use_slider : bool
+        Decides if a slider is used instead of the Prec / Next buttons when in single image mode
+    
     axs : list 
         Contains the AxesSubplots (see Matplotlib documentation) of each image.
         If the mode of the `ImageViewer` is to visualize only one image at a
@@ -276,6 +279,9 @@ class ImageViewer():
             Specifies the title of every image. If not given, the name of the 
             variable will be used as title.
         
+        use_slider : bool
+            Specifies if a slider should be used instead of the Prev / Next buttons when in single image mode
+        
         widgets : boolean
             Display the widget menu. If not specified (or set to False),
             only the button *Show Wisgets* will be displayed.
@@ -309,7 +315,7 @@ class ImageViewer():
         # Now, we make a sanity check on the keyword arguments
         accepted_arguments = ['pixel_grid', 'subplots', 'axis', 'normalize', 'clip_range', 'fix_range', 'scale_range', 'title', 
                               'num_step', 'cmap', 'new_widgets', 'callbacks', 'clickable', 'line', 'subplots', 
-                              'hist', 'widgets', 'colorbar', 'joint_zoom', 'compare']
+                              'hist', 'widgets', 'colorbar', 'joint_zoom', 'compare', 'use_slider']
         # sort in place
         accepted_arguments.sort()
         if not all([arg in accepted_arguments for arg in list(kwargs.keys())]):


### PR DESCRIPTION
Added the slider when calling the viewer with more than 5 images or if specifying `use_slider=True`. The default behavior can always be overwritten by setting `use_slider=False`. The slider callback function simply calls the `change_image` function that was used with the `Prev` / `Next` buttons to change the image.